### PR TITLE
fix: Fix pnpm.fetchDeps by adding required fetcherVersion parameter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
             nativeBuildInputs = [ pkgs.nodejs pkgs.pnpm.configHook ];
             pnpmDeps = pkgs.pnpm.fetchDeps {
               inherit (finalAttrs) version pname src;
-
+              fetcherVersion = 1;
               hash = "sha256-T0SufVzwiCumHXJzzbR4PSsUO8OkFQ2EjBp1qzxR/oI=";
             };
             buildPhase = ''


### PR DESCRIPTION
Resolves https://github.com/darksoil-studio/holochain-playground/issues/14.

Recent versions of nixpkgs require an explicit `fetcherVersion` parameter for `pnpm.fetchDeps` to track dependency fetching schema changes. Without this parameter, builds fail with "fetcherVersion is not set" assertion.

Using `fetcherVersion = 1` for compatibility with the original fetcher behavior. Version 2+ introduces stricter permission normalization but lacks clear migration documentation.

https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20fetcherVersion&type=code

https://grep.app/search?q=fetcherVersion+%3D+2